### PR TITLE
Update Flexibility of the Email Notification SMTP Settings Config

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.19', '1.20.x' ]
+        go-version: [ '1.20.x', '1.21.x' ]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -11,10 +11,10 @@ jobs:
         go-version: [ '1.20.x', '1.21.x' ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name:  Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -22,7 +22,7 @@ jobs:
         run: go version
 
       - name: Build
-        run: go build -v -ldflags "-X main.version=1.3.5"
+        run: go build -v -ldflags "-X main.version=1.3.6"
 
       - name: Test
         run: go test -v ./...

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ var configFile = "config.toml"
 var Settings struct {
 	SMTP struct {
 		EmailAddress string `valid:"-"`
+		UserName     string `valid:"-"`
 		Password     string `valid:"-"`
 		Server       string `valid:"-"`
 		Port         string `valid:"int,required"`

--- a/config/config.toml
+++ b/config/config.toml
@@ -1,6 +1,8 @@
 # SMTP credentials for sending email notifications
 [SMTP]
 	EmailAddress = "yourusername@example.com"
+	# UserName can be left as a blank string if it's the same as the EmailAddress.
+	UserName     = ""    
 	Password     = "yourpassword"
 	Server       = "smtp.gmail.com"
 	Port         = "587"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -13,6 +13,10 @@ func TestSmtpConfiguration(t *testing.T) {
 		t.Error("Config Email Address mismatch:\n", smtpSettings.EmailAddress)
 	}
 
+	if smtpSettings.UserName != "" {
+		t.Error("Config Username mismatch:\n", smtpSettings.UserName)
+	}
+
 	if smtpSettings.Password != "yourpassword" {
 		t.Error("Config Email Password mismatch:\n", smtpSettings.Password)
 	}

--- a/makefile
+++ b/makefile
@@ -13,7 +13,7 @@ SRC_PATH=.
 
 default:
 	$(eval export GO15VENDOREXPERIMENT = 1)
-	go install -ldflags "-X main.version=1.3.5" -v
+	go install -ldflags "-X main.version=1.3.6" -v
 	-mkdir -p $(DIST_PATH)
 	cp $(GOPATH)$(PATHSEP)bin$(PATHSEP)$(EXE_NAME) $(DIST_PATH)$(PATHSEP)$(EXE_NAME)
 

--- a/notifier/config.toml
+++ b/notifier/config.toml
@@ -2,6 +2,7 @@
 [SMTP]
   EmailAddress = "yourusername@example.com"
   Password 	   = "yourpassword"
+  UserName     = ""
   Server 		   = "smtp.gmail.com"
   Port 		     = "587"
 

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -74,11 +74,18 @@ func send(c database.Contact, message string, subject string, sendEmail EmailSen
 // SendEmail provides the implementation of the EmailSender type for runtime usage.
 func SendEmail(recipient string, message string, subject string) error {
 	// Set up authentication information.
-	auth := smtp.PlainAuth("", config.Settings.SMTP.EmailAddress, config.Settings.SMTP.Password,
+
+	// If the Username is not set up then use EmailAddress as the user
+	user := config.Settings.SMTP.EmailAddress
+	if config.Settings.SMTP.UserName != "" {
+		user = config.Settings.SMTP.UserName
+	}
+
+	auth := smtp.PlainAuth("", user, config.Settings.SMTP.Password,
 		config.Settings.SMTP.Server)
 	server := config.Settings.SMTP.Server + ":" + config.Settings.SMTP.Port
 	to := []string{recipient}
-	from := "sender@example.org"
+	from := config.Settings.SMTP.EmailAddress
 	msg := []byte("Subject: " + subject + "\r\n\r\n" +
 		message + "\r\n")
 	err := smtp.SendMail(server, auth, from, to, msg)

--- a/pinger/config.toml
+++ b/pinger/config.toml
@@ -1,6 +1,7 @@
 # SMTP credentials for sending email notifications
 [SMTP]
   EmailAddress = "yourusername@example.com"
+  UserName     = ""
   Password 	   = "yourpassword"
   Server 		   = "smtp.gmail.com"
   Port 		     = "587"


### PR DESCRIPTION
Added an optional UserName setting to the config.toml settings file.  This is to handle cases where the SMTP username is not the same as the email address. Also the email from address is now correctly set internally to the email address in the config settings.